### PR TITLE
fix indentatation in connection options page

### DIFF
--- a/source/fundamentals/connection/connection-options.txt
+++ b/source/fundamentals/connection/connection-options.txt
@@ -11,7 +11,7 @@ Connection Options
    :class: singlecol
 
 This section describes the MongoDB connection and authentication options
-available in the {+driver-short+}. You can configure your connection using either 
+available in the {+driver-short+}. You can configure your connection using either
 the connection URI or a ``MongoClientSettings`` object.
 
 .. _csharp-connection-uri:
@@ -23,7 +23,7 @@ Using the Connection URI
 If you pass a connection URI to the ``MongoClient`` constructor, you can include
 connection options in the string as ``<name>=<value>`` pairs. In the following example,
 the connection URI contains the ``connectTimeoutMS`` option with a value of ``60000``
-and the ``tls`` option with a value of ``true``: 
+and the ``tls`` option with a value of ``true``:
 
 .. literalinclude:: /includes/fundamentals/code-examples/connection/LocalConnectionConfig.cs
    :language: csharp
@@ -32,15 +32,15 @@ and the ``tls`` option with a value of ``true``:
 .. _csharp-mongo-client-settings:
 
 -----------------------------
-Using ``MongoClientSettings`` 
+Using ``MongoClientSettings``
 -----------------------------
 
 You can use a ``MongoClientSettings`` object to configure connection settings in code
-rather than in a connection URI. Configuring the connection this way makes it easier to 
-change settings at runtime, helps you catch errors during compilation, and provides 
+rather than in a connection URI. Configuring the connection this way makes it easier to
+change settings at runtime, helps you catch errors during compilation, and provides
 more configuration options than the connection URI.
 
-To use a ``MongoClientSettings`` object, create an instance of the class, set 
+To use a ``MongoClientSettings`` object, create an instance of the class, set
 its properties, and pass it as an argument to the ``MongoClient`` constructor:
 
 .. literalinclude:: /includes/fundamentals/code-examples/connection/MongoClientSettingsConfig.cs
@@ -51,17 +51,17 @@ Connection Options
 ------------------
 
 The following table lists each connection option available in the
-``MongoClientSettings`` class and, if possible, how to achieve the same result in 
-the connection string. If a ``MongoClientSettings`` property maps to more than one 
-option in the connection string, the **Connection URI Example** shows all 
-relevant options. 
+``MongoClientSettings`` class and, if possible, how to achieve the same result in
+the connection string. If a ``MongoClientSettings`` property maps to more than one
+option in the connection string, the **Connection URI Example** shows all
+relevant options.
 
 .. note::
 
-  If you're using a query parameter for a time duration, the value must be in 
-  milliseconds. For example, to specify 60 seconds, use the value ``60000``. If you're 
-  using a ``MongoClientSettings`` object for a time duration, use the appropriate 
-  ``TimeSpan`` value.
+   If you're using a query parameter for a time duration, the value must be in
+   milliseconds. For example, to specify 60 seconds, use the value ``60000``. If you're
+   using a ``MongoClientSettings`` object for a time duration, use the appropriate
+   ``TimeSpan`` value.
 
 .. list-table::
    :header-rows: 1
@@ -71,10 +71,10 @@ relevant options.
      - Description
 
    * - **AllowInsecureTls**
-     - | Specifies whether to relax TLS constraints as much as possible. This can include 
+     - | Specifies whether to relax TLS constraints as much as possible. This can include
        | allowing invalid certificates or hostname mismatches.
        |
-       | If this property is set to ``true`` and ``SslSettings.CheckCertificateRevocation`` 
+       | If this property is set to ``true`` and ``SslSettings.CheckCertificateRevocation``
        | is set to ``false``, the {+driver-short+} will throw an exception.
        |
        | **Data Type**: {+bool-data-type+}
@@ -82,9 +82,9 @@ relevant options.
        | **Connection URI Example**: ``tlsInsecure=true``
 
    * - **ApplicationName**
-     - | The app name the driver passes to the server in the client metadata as part of 
-       | the connection handshake. The server prints this value to the MongoDB logs once 
-       | the connection is established. The value is also recorded in the slow query logs 
+     - | The app name the driver passes to the server in the client metadata as part of
+       | the connection handshake. The server prints this value to the MongoDB logs once
+       | the connection is established. The value is also recorded in the slow query logs
        | and profile collections.
        |
        | **Data Type**: {+string-data-type+}
@@ -99,24 +99,24 @@ relevant options.
        | **Connection URI Example**: {+not-available+}
 
    * - **ClusterConfigurator**
-     - | Low-level configuration options for sockets, TLS, cluster, and others. 
-       | 
+     - | Low-level configuration options for sockets, TLS, cluster, and others.
+       |
        | **Data Type**: Action<`ClusterBuilder <{+api-root+}/T_MongoDB_Driver_Core_Configuration_ClusterBuilder.htm>`__>
        | **Default**: ``null``
        | **Connection URI Example**: {+not-available+}
 
    * - **Compressors**
-     - | The preferred compression types, in order, for wire-protocol messages sent to 
-       | or received from the server. The driver uses the first of these compression types 
-       | that the server supports. See :ref:`csharp-network-compression` for 
-       | more information. 
-       | 
+     - | The preferred compression types, in order, for wire-protocol messages sent to
+       | or received from the server. The driver uses the first of these compression types
+       | that the server supports. See :ref:`csharp-network-compression` for
+       | more information.
+       |
        | **Data Type**: `CompressorConfiguration <{+api-root+}/T_MongoDB_Driver_Core_Configuration_CompressorConfiguration.htm>`__
        | **Default**: ``null``
        | **Connection URI Example**: ``compressors=snappy,zstd``
 
    * - **ConnectTimeout**
-     - | The length of time the driver tries to establish a single TCP socket connection 
+     - | The length of time the driver tries to establish a single TCP socket connection
        | to the server before timing out.
        |
        | **DataType**: ``TimeSpan``
@@ -124,31 +124,31 @@ relevant options.
        | **Connection URI Example**: ``connectTimeoutMS=0``
 
    * - **Credential**
-     - | Settings for how the driver authenticates to the server. This includes 
+     - | Settings for how the driver authenticates to the server. This includes
        | authentication credentials, mechanism, source, and other settings.
        |
-       | If you don't specify an authentication mechanism, the driver uses either 
+       | If you don't specify an authentication mechanism, the driver uses either
        | ``SCRAM-SHA-1`` or ``SCRAM-SHA-256``, depending on the server version. See
        | :ref:`authentication mechanisms <csharp-authentication-mechanisms>` for available
        | authentication mechanisms.
        |
        | **Data Type**: `MongoCredential <{+api-root+}/T_MongoDB_Driver_MongoCredential.htm>`__
        | **Default**: ``null``
-       | **Connection URI Example**: 
+       | **Connection URI Example**:
        .. code-block:: none
-        :copyable: false
+          :copyable: false
 
-        mongodb://user1:password1&authMechanism=GSSAPI
-        &authMechanismProperties=SERVICE_NAME:other,REALM:otherrealm
-        &authSource=$external 
+          mongodb://user1:password1&authMechanism=GSSAPI
+          &authMechanismProperties=SERVICE_NAME:other,REALM:otherrealm
+          &authSource=$external
 
    * - **DirectConnection**
      - | Specifies whether to force dispatch **all** operations to the host.
        |
-       | If you specify this option, the driver doesn't accept the 
+       | If you specify this option, the driver doesn't accept the
        | :manual:`DNS seed list connection format. <reference/connection-string/#std-label-connections-dns-seedlist>`
-       | You must use the :manual:`standard connection URI format <reference/connection-string/#standard-connection-string-format/>` 
-       | instead. 
+       | You must use the :manual:`standard connection URI format <reference/connection-string/#standard-connection-string-format/>`
+       | instead.
        |
        | This property must be set to ``false`` if you specify more than one
        | host name.
@@ -158,7 +158,7 @@ relevant options.
        | **Connection URI Example**: ``directConnection=true``
 
    * - **HeartbeatInterval**
-     - | The interval between regular server-monitoring checks. Must be greater than or 
+     - | The interval between regular server-monitoring checks. Must be greater than or
        | equal to 500 milliseconds.
        |
        | **Data Type**: ``TimeSpan``
@@ -171,68 +171,68 @@ relevant options.
        | **Data Type**: ``TimeSpan``
        | **Default**: Same value as ``ConnectTimeout``
        | **Connection URI Example**: ``heartbeatTimeoutMS=5000``
-     
+
    * - **IPv6**
      - | Specifies whether the host address is in IPv6 format.
-       | 
+       |
        | **Data Type**: {+bool-data-type+}
        | **Default**: ``false``
        | **Connection URI Example**: ``ipv6=true``
 
    * - **IsFrozen**
-     - | Indicates whether the settings have been frozen. Frozen settings can't be changed. 
+     - | Indicates whether the settings have been frozen. Frozen settings can't be changed.
        | This option is read-only.
-       | 
+       |
        | **Data Type**: {+bool-data-type+}
        | **Default**: ``false``
-       | **Connection URI Example**: {+not-available+} 
+       | **Connection URI Example**: {+not-available+}
 
    * - **LinqProvider**
      - | The LINQ provider to use.
        |
        | **Data Type**: `LinqProvider <{+api-root+}/T_MongoDB_Driver_Linq_LinqProvider.htm>`__
        | **Default**: ``LinqProvider.V3``
-       | **Connection URI Example**: {+not-available+} 
+       | **Connection URI Example**: {+not-available+}
 
    * - **LoadBalanced**
-     - | Specifies whether the driver is connecting to a load balancer. You can set this 
+     - | Specifies whether the driver is connecting to a load balancer. You can set this
        | property to ``true`` only if:
-                
+
        - You specify just one host name.
        - You're not connecting to a replica set.
        - You're not using the ``SrvMaxHosts`` property.
        - You're not using the ``DirectConnection`` property.
-       
+
        | **Data Type**: {+bool-data-type+}
        | **Default**: ``false``
-       | **Connection URI Example**: ``loadBalanced=true`` 
+       | **Connection URI Example**: ``loadBalanced=true``
 
    * - **LocalThreshold**
-     - | The latency window for server eligibility. If a server's round trip takes longer 
-       | than the fastest server's round-trip time plus this value, the server isn't 
+     - | The latency window for server eligibility. If a server's round trip takes longer
+       | than the fastest server's round-trip time plus this value, the server isn't
        | eligible for selection.
-       | 
+       |
        | **Data Type**: ``TimeSpan``
        | **Default**: 15 milliseconds
-       | **Connection URI Example**: ``localThresholdMS=0`` 
+       | **Connection URI Example**: ``localThresholdMS=0``
 
    * - **LoggingSettings**
      - | The settings used for logging.
        |
        | **Data Type**: `LoggingSettings <{+api-root+}/T_MongoDB_Driver_Core_Configuration_LoggingSettings.htm>`__
        | **Default**: ``null``
-       | **Connection URI Example**: {+not-available+} 
+       | **Connection URI Example**: {+not-available+}
 
    * - **MaxConnecting**
-     - | The greatest number of connections a driver's connection pool may be 
+     - | The greatest number of connections a driver's connection pool may be
        | establishing concurrently.
        |
        | **Data Type**: {+int-data-type+}
        | **Default**: ``2``
-       | **Connection URI Example**: ``maxConnecting=3`` 
+       | **Connection URI Example**: ``maxConnecting=3``
 
    * - **MaxConnectionIdleTime**
-     - | The length of time a connection can be idle before the driver closes it. 
+     - | The length of time a connection can be idle before the driver closes it.
        |
        | **Data Type**: ``TimeSpan``
        | **Default**: 10 minutes
@@ -243,64 +243,64 @@ relevant options.
        |
        | **Data Type**: ``TimeSpan``
        | **Default**: 30 minutes
-       | **Connection URI Example**: ``maxLifetimeMS=50000`` 
+       | **Connection URI Example**: ``maxLifetimeMS=50000``
 
    * - **MaxConnectionPoolSize**
-     - | The greatest number of clients or connections the driver can create in its 
+     - | The greatest number of clients or connections the driver can create in its
        | connection pool. This count includes connections in use.
        |
        | **Data Type**: {+int-data-type+}
        | **Default**: ``100``
-       | **Connection URI Example**: ``maxPoolSize=150`` 
+       | **Connection URI Example**: ``maxPoolSize=150``
 
    * - **MinConnectionPoolSize**
-     - | The number of connections the driver should create and keep in the connection 
-       | pool even when no operations are occurring. This count includes connections 
+     - | The number of connections the driver should create and keep in the connection
+       | pool even when no operations are occurring. This count includes connections
        | in use.
        |
        | **Data Type**: {+int-data-type+}
        | **Default**: ``0``
-       | **Connection URI Example**: ``minPoolSize=1`` 
+       | **Connection URI Example**: ``minPoolSize=1``
 
    * - **ReadConcern**
-     - | The client's default read concern. 
+     - | The client's default read concern.
        | See :ref:`read concern <read-concern>` for more information.
        |
-       | **Data Type**: `ReadConcern <{+api-root+}/T_MongoDB_Driver_ReadConcern.htm>`__ 
+       | **Data Type**: `ReadConcern <{+api-root+}/T_MongoDB_Driver_ReadConcern.htm>`__
        | **Default**: ``ReadConcern.Default``
-       | **Connection URI Example**: ``readConcernLevel=local`` 
+       | **Connection URI Example**: ``readConcernLevel=local``
 
    * - **ReadEncoding**
-     - | The UTF-8 encoding to use for string deserialization. 
-       | Strict encoding will throw an exception when an invalid UTF-8 byte sequence 
+     - | The UTF-8 encoding to use for string deserialization.
+       | Strict encoding will throw an exception when an invalid UTF-8 byte sequence
        | is encountered.
        |
        | **Data Type**: ``UTF8Encoding``
        | **Default**: Strict encoding
-       | **Connection URI Example**: {+not-available+} 
+       | **Connection URI Example**: {+not-available+}
 
    * - **ReadPreference**
-     - | The client's default read-preference settings. ``MaxStaleness`` represents the 
-       | longest replication lag, in wall-clock time, that a secondary can experience and 
+     - | The client's default read-preference settings. ``MaxStaleness`` represents the
+       | longest replication lag, in wall-clock time, that a secondary can experience and
        | still be eligible for server selection. Specifying ``-1`` means no maximum.
        | See :ref:`read preference <read-preference>` for more information.
        |
        | **Data Type**: `ReadPreference <{+api-root+}/T_MongoDB_Driver_ReadPreference.htm>`__
        | **Default**: ``ReadPreference.Primary``
-       | **Connection URI Example**: 
+       | **Connection URI Example**:
        .. code-block:: none
-        :copyable: false
+          :copyable: false
 
-        readPreference=primaryPreferred
-        &maxStalenessSeconds=90
-        &readPreferenceTags=dc:ny,rack:1``
+          readPreference=primaryPreferred
+          &maxStalenessSeconds=90
+          &readPreferenceTags=dc:ny,rack:1``
        |
        .. tip::
 
-        You can include the ``readPreferenceTags`` parameter in the connection URI more 
-        than once. If you do, the client treats each instance as a separate tag set. 
-        The order of the tags in the URI determines the order for read preference. You can
-        use this parameter only if the read-preference mode is not ``primary``.
+          You can include the ``readPreferenceTags`` parameter in the connection URI more
+          than once. If you do, the client treats each instance as a separate tag set.
+          The order of the tags in the URI determines the order for read preference. You can
+          use this parameter only if the read-preference mode is not ``primary``.
 
    * - **ReplicaSetName**
      - | The name of the replica set to connect to.
@@ -324,19 +324,19 @@ relevant options.
        | **Connection URI Example**: ``retryWrites=false``
 
    * - **Scheme**
-     - | Specifies whether to use the standard connection string format (``MongoDB``) 
-       | or the DNS seed list format (``MongoDBPlusSrv``). 
-       | See :manual:`the MongoDB Manual</reference/connection-string/>` for more 
+     - | Specifies whether to use the standard connection string format (``MongoDB``)
+       | or the DNS seed list format (``MongoDBPlusSrv``).
+       | See :manual:`the MongoDB Manual</reference/connection-string/>` for more
        | information about connection string formats.
        |
-       | If the ``DirectConnection`` property is set to ``true`` and you 
-       | try to use the DNS seed list format, the {+driver-short+} will throw an 
-       | exception. 
+       | If the ``DirectConnection`` property is set to ``true`` and you
+       | try to use the DNS seed list format, the {+driver-short+} will throw an
+       | exception.
        |
        | **Data Type**: `ConnectionStringScheme <{+api-root+}/T_MongoDB_Driver_Core_Configuration_ConnectionStringScheme.htm>`__
        | **Default**: ``ConnectionStringScheme.MongoDB``
        | **Connection URI Example**: ``mongodb+srv://``
-      
+
    * - **Server**
      - | The host and port number where MongoDB is running.
        |
@@ -345,21 +345,21 @@ relevant options.
        | **Connection URI Example**: ``mongodb://sample.host:27017``
 
    * - **ServerApi**
-     - | Allows opting into Stable API versioning. See 
+     - | Allows opting into Stable API versioning. See
        | :manual:`the MongoDB Manual</reference/stable-api>` for more information about
        | Stable API versioning.
        |
        | **Data Type**: `ServerApi <{+api-root+}/T_MongoDB_Driver_ServerApi.htm>`__
        | **Default**: ``null``
-       | **Connection URI Example**: {+not-available+} 
+       | **Connection URI Example**: {+not-available+}
 
    * - **Servers**
-     - | The cluster members where MongoDB is running. 
+     - | The cluster members where MongoDB is running.
        |
        | **Data Type**: IEnumerable<`MongoServerAddress <{+api-root+}/T_MongoDB_Driver_MongoServerAddress.htm>`__>
        | **Default**: ``localhost:27017``
        | **Connection URI Example**: ``mongodb://sample.host1:27017,sample.host2:27017``
-     
+
    * - **ServerSelectionTimeout**
      - | The length of time the driver tries to select a server before timing out.
        |
@@ -368,7 +368,7 @@ relevant options.
        | **Connection URI Example**: ``serverSelectionTimeoutMS=15000``
 
    * - **SocketTimeout**
-     - | The length of time the driver tries to send or receive on a socket before 
+     - | The length of time the driver tries to send or receive on a socket before
        | timing out.
        |
        | **Data Type**: ``TimeSpan``
@@ -376,11 +376,11 @@ relevant options.
        | **Connection URI Example**: ``socketTimeoutMS=0``
 
    * - **SrvMaxHosts**
-     - | The greatest number of SRV results to randomly select when initially populating 
-       | the seedlist or, during SRV polling, adding new hosts to the topology. 
+     - | The greatest number of SRV results to randomly select when initially populating
+       | the seedlist or, during SRV polling, adding new hosts to the topology.
        |
        | You can use this property only if the connection-string scheme is set
-       | to ``ConnectionStringScheme.MongoDBPlusSrv``. You cannot use it when connecting 
+       | to ``ConnectionStringScheme.MongoDBPlusSrv``. You cannot use it when connecting
        | to a replica set.
        |
        | **Data Type**: {+int-data-type+}
@@ -388,11 +388,11 @@ relevant options.
        | **Connection URI Example**: ``srvMaxHosts=3``
 
    * - **SslSettings**
-     - | TLS/SSL options, including client certificates, revocation handling, and 
+     - | TLS/SSL options, including client certificates, revocation handling, and
        | enabled and disabled TLS/SSL protocols.
        |
-       | If ``SslSettings.CheckCertificateRevocation`` is set to ``false`` and 
-       | ``AllowInsecureTls`` is set to ``true``, the {+driver-short+} will throw 
+       | If ``SslSettings.CheckCertificateRevocation`` is set to ``false`` and
+       | ``AllowInsecureTls`` is set to ``true``, the {+driver-short+} will throw
        | an exception.
        |
        | **Data Type**: `SslSettings <{+api-root+}/T_MongoDB_Driver_SslSettings.htm>`__
@@ -400,8 +400,8 @@ relevant options.
        | **Connection URI Example**: ``tlsDisableCertificateRevocationCheck=false``
 
    * - **UseTls**
-     - | Specifies whether to require TLS for connections to the server. If you use 
-       | a scheme of ``"mongodb+srv"`` or specify other TLS options, 
+     - | Specifies whether to require TLS for connections to the server. If you use
+       | a scheme of ``"mongodb+srv"`` or specify other TLS options,
        | this option defaults to ``true``.
        |
        | **Data Type**: {+bool-data-type+}
@@ -409,15 +409,15 @@ relevant options.
        | **Connection URI Example**: ``tls=true``
 
    * - **WaitQueueTimeout**
-     - | The length of time the driver tries to check out a connection from a 
-       | server's connection pool before timing out. 
+     - | The length of time the driver tries to check out a connection from a
+       | server's connection pool before timing out.
        |
        | **Data Type**: ``TimeSpan``
        | **Default**: 2 minutes
        | **Connection URI Example**: ``waitQueueTimeoutMS=0``
 
    * - **WriteConcern**
-     - | The default write-concern settings, including write timeout and 
+     - | The default write-concern settings, including write timeout and
        | journaling, for the client.
        | See :ref:`write concern <wc-j>` for more information.
        |
@@ -427,9 +427,9 @@ relevant options.
 
    * - **WriteEncoding**
      - | Specifies whether UTF-8 string serialization is strict or lenient. With strict
-       | encoding, the driver will throw an exception when it encounters an invalid 
+       | encoding, the driver will throw an exception when it encounters an invalid
        | UTF-8 byte sequence.
        |
        | **Data Type**: ``UTF8Encoding``
        | **Default**: Strict encoding
-       | **Connection URI Example**: {+not-available+} 
+       | **Connection URI Example**: {+not-available+}

--- a/source/fundamentals/connection/connection-options.txt
+++ b/source/fundamentals/connection/connection-options.txt
@@ -135,6 +135,7 @@ relevant options.
        | **Data Type**: `MongoCredential <{+api-root+}/T_MongoDB_Driver_MongoCredential.htm>`__
        | **Default**: ``null``
        | **Connection URI Example**:
+
        .. code-block:: none
           :copyable: false
 
@@ -288,6 +289,7 @@ relevant options.
        | **Data Type**: `ReadPreference <{+api-root+}/T_MongoDB_Driver_ReadPreference.htm>`__
        | **Default**: ``ReadPreference.Primary``
        | **Connection URI Example**:
+
        .. code-block:: none
           :copyable: false
 
@@ -295,6 +297,7 @@ relevant options.
           &maxStalenessSeconds=90
           &readPreferenceTags=dc:ny,rack:1``
        |
+
        .. tip::
 
           You can include the ``readPreferenceTags`` parameter in the connection URI more

--- a/source/fundamentals/connection/connection-options.txt
+++ b/source/fundamentals/connection/connection-options.txt
@@ -296,6 +296,7 @@ relevant options.
           readPreference=primaryPreferred
           &maxStalenessSeconds=90
           &readPreferenceTags=dc:ny,rack:1``
+
        |
 
        .. tip::


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-golang/blob/master/REVIEWING.md)

JIRA - None
Staging - https://docs-mongodbcom-staging.corp.mongodb.com/csharp/docsworker-xlarge/connection-options-indentation-fixes/

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
