### PR TITLE
DOCSP-29080: use sharedinclude in encrypt page

### DIFF
--- a/source/fundamentals.txt
+++ b/source/fundamentals.txt
@@ -34,4 +34,4 @@ Fundamentals
 - :ref:`csharp-linq`
 - :ref:`csharp-class-mapping`
 - :ref:`csharp-logging`
-- :ref:`csharp-fle`
+- :ref:`Encrypt Fields <csharp-fle>`

--- a/source/fundamentals.txt
+++ b/source/fundamentals.txt
@@ -21,6 +21,7 @@ Fundamentals
    /fundamentals/linq
    /fundamentals/class-mapping
    /fundamentals/logging
+   /fundamentals/encrypt-fields
 
 - :ref:`Connecting to MongoDB <csharp-connection>`
 - :ref:`csharp-crud`
@@ -33,3 +34,4 @@ Fundamentals
 - :ref:`csharp-linq`
 - :ref:`csharp-class-mapping`
 - :ref:`csharp-logging`
+- :ref:`csharp-fle`

--- a/source/fundamentals/encrypt-fields.txt
+++ b/source/fundamentals/encrypt-fields.txt
@@ -1,0 +1,3 @@
+.. _csharp-fle:
+
+.. sharedinclude:: dbx/encrypt-fields.rst


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-golang/blob/master/REVIEWING.md)

JIRA - [DOCSP-29080](https://jira.mongodb.org/browse/DOCSP-29080)
Staging - https://docs-mongodbcom-staging.corp.mongodb.com/csharp/docsworker-xlarge/DOCSP-29080-encrypt-include-link/fundamentals/encrypt-fields/

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST? **No errors related to this ticket**
- [x] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [x] Are all the links working?
