### PR TITLE
Remove orphan page with no content

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -4,3 +4,5 @@ define: versions 2.19 master
 
 raw: ${prefix}/ -> ${base}/current/
 raw: ${prefix}/stable -> ${base}/current/
+
+[*-master]: ${prefix}/${version}/fundamentals/connection/network-compression/ -> ${base}/${version}/

--- a/source/fundamentals/connection/network-compression.txt
+++ b/source/fundamentals/connection/network-compression.txt
@@ -1,5 +1,0 @@
-.. _csharp-network-compression:
-
-===================
-Network Compression
-===================


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-golang/blob/master/REVIEWING.md)

Removes orphan page (network-compression.txt) that is not referenced anywhere, but is blank. This page is receiving page views and is indexed on Google. It should be removed until content can be created.
 
JIRA - None
Staging - (nothing to be shown)
https://docs-mongodbcom-staging.corp.mongodb.com/csharp/docsworker-xlarge/DOCSP-29771-meta/

mut-redirects output
```
Redirect 301 /docs/drivers/csharp/2.19/fundamentals/connection/network-compression/ https://www.mongodb.com/docs/drivers/csharp/2.19/
Redirect 301 /docs/drivers/csharp/master/fundamentals/connection/network-compression/ https://www.mongodb.com/docs/drivers/csharp/master/
```

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
