### PR TITLE
replace v2.20 compat tables with sharedincludes

### DIFF
--- a/source/compatibility.txt
+++ b/source/compatibility.txt
@@ -21,7 +21,7 @@ The first column lists the driver version.
 
 .. sharedinclude:: dbx/compatibility-table-legend.rst
 
-.. include:: /includes/mongodb-compatibility-table-csharp.rst
+.. sharedinclude:: dbx/mongodb-compatibility-table-csharp.rst
 
 Language Compatibility
 ----------------------
@@ -31,7 +31,7 @@ The following compatibility table specifies the recommended version of the
 
 The first column lists the driver version.
 
-.. include:: /includes/language-compatibility-table-csharp.rst
+.. sharedinclude:: dbx/language-compatibility-table-csharp.rst
 
 For more information on how to read the compatibility tables, see our guide on 
 :ref:`MongoDB Compatibility Tables. <about-driver-compatibility>`


### PR DESCRIPTION
# Pull Request Info

[Staging](https://docs-mongodbcom-staging.corp.mongodb.com/csharp/docsworker-xlarge/v2.20/compatibility/)

- [x] Is this free of any warnings or errors in the RST?
