### PR TITLE
Add Option for 'set' command for Environment Variables along with Export

### DIFF
--- a/source/quick-start.txt
+++ b/source/quick-start.txt
@@ -4,7 +4,12 @@
 Quick Start
 ===========
 
-.. default-domain:: mongodb
+.. facet::
+   :name: genre
+   :values: tutorial
+
+.. meta::
+   :keywords: set up, runnable app, initialize, connect
 
 .. contents:: On this page
    :local:

--- a/source/quick-start.txt
+++ b/source/quick-start.txt
@@ -35,7 +35,8 @@ a connection string similar to the following in your copy buffer:
 Set Your Connection String
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Run the following code at the command prompt to save your MongoDB connection string to an 
+Run the following code at the command prompt to save your MongoDB
+:ref:`connection string <csharp-connect-to-mongodb>` to an 
 environment variable. This method is safer than including your credentials in your source 
 code. 
 
@@ -47,6 +48,8 @@ code.
 
    Make sure to replace the ``<username>`` and ``<password>`` sections of the connection 
    string with the username and password of your Atlas user.
+
+For more information about connection strings, see :manual:`Connection Strings </reference/connection-string/#connection-strings>`.
 
 Set Up Your Project
 -------------------

--- a/source/quick-start.txt
+++ b/source/quick-start.txt
@@ -42,7 +42,7 @@ code.
 
 .. code-block:: bash
 
-   export MONGODB_URI='<your MongoDB URI>'
+   export MONGODB_URI="<your MongoDB URI>"
 
 .. important::
 


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-golang/blob/master/REVIEWING.md)

The difference between single and double quotes is more significant in bash, which would account for the difference in processing the statements listed in the ticket:
```bash
export MONGODB_URI='<your MongoDB URI>'
```
and
```bash
set MONGODB_URI="<your MongoDB URI>"
```
Since `export` sets a global variable, and no `set` options are being used, I think `export` is more universally useful in this situation.

JIRA - <https://jira.mongodb.org/browse/DOCSP-37263>
Staging - <https://docs-mongodbcom-staging.corp.mongodb.com/csharp/docsworker-xlarge/DOCSP-37263/quick-start/>

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
- [ ] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
