### PR TITLE
[C#] Code Snippet for Atlas Search Autocomplete doesn't work

### DIFF
--- a/source/fundamentals/atlas-search.txt
+++ b/source/fundamentals/atlas-search.txt
@@ -107,6 +107,7 @@ collection using the string "Gib" in the ``make`` field.
    :dedent:
 
 .. note::
+   
    If the field you are searching has a search index, it must be included in your ``Autocomplete`` call:
    ``Search.Autocomplete(g => g.Make, "Gib"), indexName: <make_search_index>)``
 

--- a/source/fundamentals/atlas-search.txt
+++ b/source/fundamentals/atlas-search.txt
@@ -108,8 +108,7 @@ collection using the string "Gib" in the ``make`` field.
 
 .. note::
    
-   If the field you are searching has a search index, it must be included in your ``Autocomplete`` call:
-   ``Search.Autocomplete(g => g.Make, "Gib"), indexName: <make_search_index>)``
+   If the field you are searching has a search index, it must be included in your ``Autocomplete`` call. If a search index does not exist, the default index is used.
 
 The search returns the following document:
 

--- a/source/fundamentals/atlas-search.txt
+++ b/source/fundamentals/atlas-search.txt
@@ -108,7 +108,7 @@ collection using the string "Gib" in the ``make`` field.
 
 .. note::
    
-   If the field you are searching has a search index, it must be included in your ``Autocomplete`` call. If a search index does not exist, the default index is used.
+   If the field you are searching on is indexed by a search index, , you must pass the index name to the ``Autocomplete`` call. If a search index does not exist, the default index is used.
 
 The search returns the following document:
 

--- a/source/fundamentals/atlas-search.txt
+++ b/source/fundamentals/atlas-search.txt
@@ -106,6 +106,10 @@ collection using the string "Gib" in the ``make`` field.
    :language: csharp
    :dedent:
 
+.. note::
+   If the field you are searching has a search index, it must be included in your ``Autocomplete`` call:
+   ``Search.Autocomplete(g => g.Make, "Gib"), indexName: <make_search_index>)``
+
 The search returns the following document:
 
 .. code-block:: json

--- a/source/fundamentals/atlas-search.txt
+++ b/source/fundamentals/atlas-search.txt
@@ -108,7 +108,7 @@ collection using the string "Gib" in the ``make`` field.
 
 .. note::
    
-   If the field you are searching on is indexed by a search index, , you must pass the index name to the ``Autocomplete`` call. If a search index does not exist, the default index is used.
+   If the field you are searching on is indexed by a search index, you must pass the index name to the ``Autocomplete`` call. If a search index does not exist, the default index is used.
 
 The search returns the following document:
 

--- a/source/includes/fundamentals/code-examples/atlas-search/AtlasSearchExamples.cs
+++ b/source/includes/fundamentals/code-examples/atlas-search/AtlasSearchExamples.cs
@@ -29,7 +29,7 @@ public class AtlasSearchExamples
         // Finds documents with a "make" value that contains the string fragment "Gib"
         // start-autocomplete-search
         var result = guitarsCollection.Aggregate()
-            .Search(Builders<Guitar>.Search.Autocomplete(g => g.Make, "Gib"))
+            .Search(Builders<Guitar>.Search.Autocomplete(g => g.Make, "Gib"), indexName: "guitarmakes")
             .ToList();
         // end-autocomplete-search
 


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-golang/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-37267>
Staging - <https://docs-mongodbcom-staging.corp.mongodb.com/csharp/docsworker-xlarge/DOCSP-37267/fundamentals/atlas-search/#std-label-csharp-atlas-search>

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
- [x] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
