### PR TITLE
DOCSP-38781: remove v1.11 link

### DIFF
--- a/source/previous-versions.txt
+++ b/source/previous-versions.txt
@@ -26,4 +26,3 @@ driver.
 - `Version 2.2 <https://mongodb.github.io/mongo-csharp-driver/2.2/>`__
 - `Version 2.1 <https://mongodb.github.io/mongo-csharp-driver/2.1/>`__
 - `Version 2.0 <https://mongodb.github.io/mongo-csharp-driver/2.0/>`__
-- `Version 1.11 <https://mongodb.github.io/mongo-csharp-driver/1.11/>`__


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-golang/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-38781>
Staging - https://preview-mongodbcchomongodb.gatsbyjs.io/csharp/DOCSP-38781-remove-1.11-link/previous-versions/

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [x] Are all the links working?
- [ ] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
