### PR TITLE
DOCSP-34013: Add DNS seedlist default behavior to C# TLS/SSL guide

### DIFF
--- a/source/fundamentals/connection/tls.txt
+++ b/source/fundamentals/connection/tls.txt
@@ -36,7 +36,7 @@ through a parameter in your connection string.
    ``false`` in your connection string or ``MongoClientSettings`` instance.
 
    To learn more about connection behavior when you use a DNS seedlist,
-   see the :manual:`SRV Connection Format </reference/connection-string/#std-label-connections-dns-seedlist>`
+   see the :manual:`SRV Connection Format </reference/connection-string/#srv-connection-format>`
    section in the Server manual.
 
 .. tabs::

--- a/source/fundamentals/connection/tls.txt
+++ b/source/fundamentals/connection/tls.txt
@@ -36,7 +36,7 @@ through a parameter in your connection string.
    ``false`` in your connection string or ``MongoClientSettings`` instance.
 
    To learn more about connection behavior when you use a DNS seedlist,
-   see the :manual:`SRV Connection Format </reference/connection-string/#std-label-connections-dns-seedlist>`__
+   see the :manual:`SRV Connection Format </reference/connection-string/#std-label-connections-dns-seedlist>`
    section in the Server manual.
 
 .. tabs::

--- a/source/fundamentals/connection/tls.txt
+++ b/source/fundamentals/connection/tls.txt
@@ -29,6 +29,16 @@ You can enable TLS for the connection to your MongoDB instance
 in two different ways: using a property on a ``MongoClientSettings`` object or
 through a parameter in your connection string.
 
+.. note::
+
+   If you connect by using the DNS seedlist protocol, note that the driver enables
+   TLS/SSL by default. To disable it, set the ``tls`` or ``ssl`` parameter value to
+   ``false`` in your connection string or ``MongoClientSettings`` instance.
+
+   To learn more about connection behavior when you use a DNS seedlist,
+   see the :manual:`SRV Connection Format </reference/connection-string/#std-label-connections-dns-seedlist>`__
+   section in the Server manual.
+
 .. tabs::
 
    .. tab:: MongoClientSettings

--- a/source/fundamentals/connection/tls.txt
+++ b/source/fundamentals/connection/tls.txt
@@ -31,7 +31,7 @@ through a parameter in your connection string.
 
 .. note::
 
-   If you connect by using the DNS seedlist protocol, note that the driver enables
+   If you connect by using the DNS seedlist protocol, the driver enables
    TLS/SSL by default. To disable it, set the ``tls`` or ``ssl`` parameter value to
    ``false`` in your connection string or ``MongoClientSettings`` instance.
 


### PR DESCRIPTION
# Pull Request Info
Added note to C# driver guide on configuring TLS/SSL connections. Modeled after a [similar note in the Java driver guide for the same configurations](https://www.mongodb.com/docs/drivers/java/sync/current/fundamentals/connection/tls/).

[PR Reviewing Guidelines](https://github.com/mongodb/docs-golang/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-34013>
Staging - <https://preview-mongodbmcmorisi.gatsbyjs.io/csharp/DOCSP-34013-csharp-TLS-default/fundamentals/connection/tls/>

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
- [x] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
