### PR TITLE
DOCSP-37272: Various quick fixes to wording and accuracy

### DIFF
--- a/source/connection-troubleshooting.txt
+++ b/source/connection-troubleshooting.txt
@@ -202,7 +202,7 @@ driver could generate this error.
 Also ensure that the user has the appropriate permissions for the message you
 are sending. MongoDB uses Role-Based Access Control (RBAC) to control access
 to a MongoDB deployment. For more information about how to configure RBAC in MongoDB,
-see :manual:`Default MongoDB Port </core/authorization/>`.
+see :manual:`Role-Based Access Control </core/authorization/>`.
 
 Configure Your Firewall
 -----------------------

--- a/source/fundamentals/builders.txt
+++ b/source/fundamentals/builders.txt
@@ -272,6 +272,9 @@ single field path``, in this case using ``Category``:
          // Using string-based field names
          var keys = builder.Wildcard("Category");
 
+For more information about how to use wildcard indexes, see 
+:manual:`Wildcard Indexes </core/indexes/index-types/index-wildcard>`.
+
 Build an Aggregation Pipeline
 -----------------------------
 

--- a/source/fundamentals/connection/tls.txt
+++ b/source/fundamentals/connection/tls.txt
@@ -25,9 +25,9 @@ the :ref:`connection string <csharp-connection-uri>` or
 Enable TLS
 ----------
 
-You can enable TLS for the connection to your MongoDB instance
-in two different ways: using a property on a ``MongoClientSettings`` object or
-through a parameter in your connection string.
+By default, TLS is disabled when connecting to MongoDB instances. You can enable TLS
+for the connection to your MongoDB instance in two different ways: using a property
+on a ``MongoClientSettings`` object or through a parameter in your connection string.
 
 .. note::
 

--- a/source/fundamentals/serialization/class-mapping.txt
+++ b/source/fundamentals/serialization/class-mapping.txt
@@ -140,7 +140,7 @@ Mapping with Constructors
 By default, the {+driver-short+} can automatically map a class only if the class has
 a constructor with no arguments. If you want the driver to use a constructor that accepts
 one or more arguments, you can add the ``BsonConstructor`` attribute to the constructor.
-In this case, the driver the driver examines the types to determine how to map the
+In this case, the driver examines the types to determine how to map the
 constructor arguments to class properties or fields.
 
 When the driver creates a class map for the following ``Person`` class, it will use the 

--- a/source/quick-start.txt
+++ b/source/quick-start.txt
@@ -94,7 +94,9 @@ Query Your MongoDB Cluster from Your Application
 ------------------------------------------------
 
 In this step, you'll use the {+driver-short+} 
-to connect to your MongoDB cluster and run a query on the sample data.
+to connect to your MongoDB cluster and run a query on the sample data. You'll need your
+preferred text editor or :wikipedia:`integrated development environment (IDE) <Integrated development environment>`
+installed and running.
 
 Open the file named ``Program.cs`` in the base directory of your project. Copy the
 following sample code into ``Program.cs`` 


### PR DESCRIPTION
# Pull Request Info
Series of quick fixes from epic DOCSP-37272


[PR Reviewing Guidelines](https://github.com/mongodb/docs-golang/blob/master/REVIEWING.md)

JIRA
Epic: [DOCSP-37272](https://jira.mongodb.org/browse/DOCSP-37272)

Individual tasks:
* [DOCSP-39018](https://jira.mongodb.org/browse/DOCSP-39018): Mention that TLS is disabled by default
* [DOCSP-39017](https://jira.mongodb.org/browse/DOCSP-39017): Point users to installing/running an IDE before quick start steps
* [DOCSP-39021](https://jira.mongodb.org/browse/DOCSP-39021): Add additional resources for Wildcard Indexes
* [DOCSP-39025](https://jira.mongodb.org/browse/DOCSP-39025): Remove "the driver" double mention
* [DOCSP-39028](https://jira.mongodb.org/browse/DOCSP-39028): Remedy incorrect link text

Staging
* TLS disabled by default: https://preview-mongodbmcmorisi.gatsbyjs.io/csharp/DOCSP-37272-quick-wins/fundamentals/connection/tls/
* Install IDE prerequisite: https://preview-mongodbmcmorisi.gatsbyjs.io/csharp/DOCSP-37272-quick-wins/#query-your-mongodb-cluster-from-your-application
* Wildcard Indexes: https://preview-mongodbmcmorisi.gatsbyjs.io/csharp/DOCSP-37272-quick-wins/fundamentals/builders/#define-index-keys
* "The driver" x2: https://preview-mongodbmcmorisi.gatsbyjs.io/csharp/DOCSP-37272-quick-wins/fundamentals/serialization/class-mapping/#mapping-with-constructors
* Incorrect link text: https://preview-mongodbmcmorisi.gatsbyjs.io/csharp/DOCSP-37272-quick-wins/connection-troubleshooting/

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
