### PR TITLE
DOCSP-41883 Show binding redirects on upgrade page

### DIFF
--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -50,6 +50,47 @@ changes between the current and upgrade versions. For example, if you
 are upgrading the driver from v2.0 to v2.20, address all breaking changes from
 the version after v2.0 including any listed under v2.20.
 
+.. _csharp-breaking-changes-2.28.0:
+
+Version 2.28.0 Breaking Changes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- All {+driver-short+} components are strongly named. If your application
+  has dependencies that reference multiple {+driver-short+} versions, you must create
+  binding redirects, as shown in the following example:
+
+  .. code-block:: csharp
+
+     <configuration>
+         <runtime>
+             <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+                 <dependentAssembly>
+                     <assemblyIdentity name="MongoDB.Driver"
+                                       publicKeyToken="94992a530f44e321"
+                                       culture="neutral" />
+                     <bindingRedirect oldVersion="2.28.0.0"
+                                      newVersion="version number to use" />
+                 </dependentAssembly>
+                 <dependentAssembly>
+                     <assemblyIdentity name="MongoDB.Bson"
+                                       publicKeyToken="94992a530f44e321"
+                                       culture="neutral" />
+                     <bindingRedirect oldVersion="2.28.0.0"
+                                      newVersion="version number to use" />
+                 </dependentAssembly>
+                 <dependentAssembly>
+                     <assemblyIdentity name="MongoDB.Driver.Core"
+                                       publicKeyToken="94992a530f44e321"
+                                       culture="neutral" />
+                     <bindingRedirect oldVersion="2.28.0.0"
+                                      newVersion="<version number to use>" />
+                 </dependentAssembly>
+             </assemblyBinding>
+         </runtime>
+     </configuration>
+
+  
+
 .. _csharp-breaking-changes-2.21.0:
 
 Version 2.21.0 Breaking Changes

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -4,6 +4,13 @@
 Upgrade Driver Versions
 =======================
 
+.. facet::
+   :name: genre
+   :values: reference
+
+.. meta::
+   :keywords: update, breaking change, releases
+
 .. contents:: On this page
    :local:
    :backlinks: none

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -76,14 +76,14 @@ Version 2.28.0 Potential Breaking Change
                                        publicKeyToken="94992a530f44e321"
                                        culture="neutral" />
                      <bindingRedirect oldVersion="2.28.0.0"
-                                      newVersion="version number to use" />
+                                      newVersion="<version number to use>" />
                  </dependentAssembly>
                  <dependentAssembly>
                      <assemblyIdentity name="MongoDB.Bson"
                                        publicKeyToken="94992a530f44e321"
                                        culture="neutral" />
                      <bindingRedirect oldVersion="2.28.0.0"
-                                      newVersion="version number to use" />
+                                      newVersion="<version number to use>" />
                  </dependentAssembly>
                  <dependentAssembly>
                      <assemblyIdentity name="MongoDB.Driver.Core"
@@ -95,8 +95,6 @@ Version 2.28.0 Potential Breaking Change
              </assemblyBinding>
          </runtime>
      </configuration>
-
-  
 
 .. _csharp-breaking-changes-2.21.0:
 

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -52,8 +52,8 @@ the version after v2.0 including any listed under v2.20.
 
 .. _csharp-breaking-changes-2.28.0:
 
-Version 2.28.0 Breaking Changes
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Version 2.28.0 Potential Breaking Change
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - All {+driver-short+} components are strongly named. If your application
   has dependencies that reference multiple {+driver-short+} versions, you must create

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -40,7 +40,7 @@ What's New in 2.28
 .. warning:: Potential Breaking Change in v2.28
 
    - All {+driver-short+} components are strongly named. If your application
-     If your application has dependencies that reference multiple {+driver-short+}
+     has dependencies that reference multiple {+driver-short+}
      versions, you must create binding redirects to manage those dependencies.
      For more information, see :ref:`csharp-breaking-changes-2.28.0`.
 

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -37,10 +37,15 @@ Learn what's new in:
 What's New in 2.28
 ------------------
 
+.. warning:: Potential Breaking Change in v2.28
+
+   - All {+driver-short+} components are strongly named. If your application
+     If your application has dependencies that reference multiple {+driver-short+}
+     versions, you must create binding redirects to manage those dependencies.
+     For more information, see :ref:`csharp-breaking-changes-2.28.0`.
+
 The 2.28 driver release includes the following new features:
 
-- All {+driver-short+} components are strongly named. If your application
-  contains binding redirects or dynamic assembly loading, it might require modification.
 - Adds support for additional numeric conversions involving ``Nullable<T>``.
 - Adds support for the ``delegated`` option when using KMIP for :ref:`CSFLE or
   Queryable Encryption <csharp-fle>`.


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-golang/blob/master/REVIEWING.md)

JIRA - https://jira.mongodb.org/browse/DOCSP-41883
Staging - https://preview-mongodbjordansmith721.gatsbyjs.io/csharp/DOCSP-41883-binding-redirects/upgrade/#version-2.28.0-potential-breaking-change
https://preview-mongodbjordansmith721.gatsbyjs.io/csharp/DOCSP-41883-binding-redirects/whats-new/#what-s-new-in-2.28

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
- [x] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
