### PR TITLE
(DOCSP-44251) [C#] Remove EOL v2.19 & v2.20 from "What's New" for v2.21+

### DIFF
--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -30,8 +30,6 @@ Learn what's new in:
 * :ref:`Version 2.23 <version-2.23>`
 * :ref:`Version 2.22 <version-2.22>`
 * :ref:`Version 2.21 <version-2.21>`
-* :ref:`Version 2.20 <version-2.20>`
-* :ref:`Version 2.19 <version-2.19>`
 
 .. _upcoming-breaking-changes:
 
@@ -354,31 +352,3 @@ The 2.21 driver release includes the following new features:
 - Supports the Atlas Search :atlas:`embeddedDocument </atlas-search/embedded-document/>` operator.
 - Offers an API for Atlas Search index management.
 - Accepts anonymous types in the ``ObjectSerializer.DefaultAllowedTypes`` method.
-
-.. _version-2.20:
-
-What's New in 2.20
-------------------
-
-The 2.20 driver release includes the following new features:
-
-- Added full support for {+mdb-server+} version 7.0.0.
-- Added support for equality query types in Queryable Encryption GA.
-- Improvements to LINQ3 integration.
-- Improvements to serialization features.
-- Improvements to the logging framework.
-
-.. _version-2.19:
-
-What's New in 2.19
-------------------
-
-The 2.19 driver release includes the following new features:
-
-- The ``ObjectSerializer`` allows deserialization of only safe types, as determined by
-  the configurable ``AllowedTypes`` function.
-- Changed the default ``LinqProvider`` to LINQ3.
-- Added Atlas Search (``$search``) support to builders, aggregation pipelines, and LINQ3.
-- Added support for ``$bucket`` and ``$bucketAuto`` aggregation pipeline stages in LINQ3.
-- Added support for automatic KMS credentials for Azure VM Managed Identities.
-- Added native support for AWS IAM roles.


### PR DESCRIPTION
These versions have reached their end-of-life per the archival policy (linked in Epic). Release notes for these versions and all earlier versions should also be removed from current versions (v2.21 and later). This preserves the changelog information in the original versions (e.g. v2.19 notes are in the v2.19 "What's New", but not later versions).

[PR Reviewing Guidelines](https://github.com/mongodb/docs-golang/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-44251>
STAGING - <https://deploy-preview-262--mongodb-docs-csharp.netlify.app/whats-new/>

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
- [ ] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
