### PR TITLE
DOCSP-44180: Clarify _id field behavior for nested documents

### DIFF
--- a/source/fundamentals/serialization/poco.txt
+++ b/source/fundamentals/serialization/poco.txt
@@ -256,6 +256,11 @@ The following code sample maps the ``Identifier`` property to the
    (for example, if your POCO includes properties named ``Id`` and ``_id``), 
    the driver throws a ``BsonSerializationException``.
 
+.. note:: Nested Document Ids
+
+   The ``_id`` field mapping logic described in this section only applies to the
+   root document, and does not apply to nested documents.
+
 Omit Empty Fields
 ~~~~~~~~~~~~~~~~~
 

--- a/source/fundamentals/serialization/poco.txt
+++ b/source/fundamentals/serialization/poco.txt
@@ -259,7 +259,7 @@ The following code sample maps the ``Identifier`` property to the
 .. note:: Nested Document Ids
 
    The ``_id`` field mapping logic described in this section only applies to the
-   root document, and does not apply to nested documents.
+   root document and does not apply to nested documents.
 
 Omit Empty Fields
 ~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-golang/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-44180>

### Staging Links
<!-- start insert-links -->
<li><a href=https://deploy-preview-323--mongodb-docs-csharp.netlify.app/fundamentals/serialization/poco>fundamentals/serialization/poco</a></li>
<!-- end insert-links -->

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
- [x] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
