### PR TITLE
DOCSP-36080: Add DateFromString to list of supported LINQ methods

### DIFF
--- a/source/fundamentals/linq.txt
+++ b/source/fundamentals/linq.txt
@@ -779,8 +779,7 @@ the :ref:`<csharp-builders-out>` section.
 Supported Methods
 -----------------
 
-The following are some of the methods supported by the  {+driver-long+}
-implementation of LINQ:
+The following are some methods supported by the {+driver-long+} implementation of LINQ:
 
 .. list-table::
    :header-rows: 1
@@ -800,6 +799,9 @@ implementation of LINQ:
 
    * - ``LongCount``
      - Returns an ``Int64`` that represents the number of documents that match the specified criteria
+
+   * - ``DateFromString``
+     - Converts a ``string`` to a ``DateTime`` object
 
    * - ``Distinct``
      - Returns distinct documents that match the specified criteria


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-golang/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-36080>

### Staging Links
<!-- start insert-links -->
<li><a href=https://deploy-preview-363--mongodb-docs-csharp.netlify.app/fundamentals/linq>fundamentals/linq</a></li>
<!-- end insert-links -->

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
- [x] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
