### PR TITLE
DOCSP-46235: Add links to LINQ in API docs

### DIFF
--- a/source/fundamentals/linq.txt
+++ b/source/fundamentals/linq.txt
@@ -1060,3 +1060,14 @@ uses a scalar operation, then prints the translated query:
    ``LoggedStages`` is not thread-safe. Executing a query and accessing the
    associated ``LoggedStages`` property from multiple threads might have
    non-deterministic results.
+
+Additional Information
+----------------------
+
+API Documentation
+~~~~~~~~~~~~~~~~~
+
+For a complete list of supported LINQ methods, see the following API Documentation:
+
+- `LINQ <{+new-api-root+}/MongoDB.Driver/MongoDB.Driver.Linq.html>`__
+- `MongoQueryable <{+new-api-root+}/MongoDB.Driver/MongoDB.Driver.Linq.MongoQueryable.html>`__

--- a/source/fundamentals/linq.txt
+++ b/source/fundamentals/linq.txt
@@ -1061,13 +1061,10 @@ uses a scalar operation, then prints the translated query:
    associated ``LoggedStages`` property from multiple threads might have
    non-deterministic results.
 
-Additional Information
-----------------------
-
 API Documentation
-~~~~~~~~~~~~~~~~~
+-----------------
 
-For a complete list of supported LINQ methods, see the following API Documentation:
+For a complete list of supported LINQ methods, see the following API documentation:
 
 - `LINQ <{+new-api-root+}/MongoDB.Driver/MongoDB.Driver.Linq.html>`__
 - `MongoQueryable <{+new-api-root+}/MongoDB.Driver/MongoDB.Driver.Linq.MongoQueryable.html>`__


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-golang/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-46235>

### Staging Links
<!-- start insert-links -->
<li><a href=https://deploy-preview-441--docs-csharp.netlify.app/fundamentals/linq>fundamentals/linq</a></li>
<!-- end insert-links -->

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
- [x] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
