### PR TITLE
DOCSP-45048 - Vector search params

### DIFF
--- a/source/fundamentals/builders.txt
+++ b/source/fundamentals/builders.txt
@@ -430,14 +430,9 @@ Perform an Atlas Vector Search
 
 .. include:: /includes/vector-search-intro.rst
 
-You can use a ``$vectorSearch`` stage to perform a semantic search on the ``plot_embedding``
-field of the documents in the collection.
-The following example shows how to use builders to generate an aggregation pipeline to
-perform the following operations:
+   .. replacement:: mechanism 
 
-- Perform a vector search on the Atlas Vector Search index of the ``plot_embedding``
-  field using vector embeddings for the string ``"time travel"``
-- Fetch the ``Title`` and ``Plot`` fields from documents found in the vector search
+      builders
 
 .. code-block:: csharp
 

--- a/source/fundamentals/builders.txt
+++ b/source/fundamentals/builders.txt
@@ -439,6 +439,8 @@ have a defined Atlas Vector Search index before you can perform a vector search 
    :atlas:`Create an Atlas Vector Search Index </atlas-vector-search/create-index>` in the
    Atlas manual.
 
+.. include:: /includes/vector-search-parameters.rst
+
 Consider the ``embedded_movies`` collection in the ``sample_mflix`` database. You
 can use a ``$vectorSearch`` stage to perform a semantic search on the ``plot_embedding``
 field of the documents in the collection.
@@ -446,7 +448,8 @@ field of the documents in the collection.
 The following example shows how to use builders to generate an aggregation pipeline to
 perform the following operations:
 
-- Performs a vector search on the Atlas Vector Search index of the ``plot_embedding`` field using vector embeddings for the string ``"time travel"``
+- Performs a vector search on the Atlas Vector Search index of the ``plot_embedding``
+  field using vector embeddings for the string ``"time travel"``
 - Fetches the ``Title`` and ``Plot`` fields from documents found in the vector search
 
 .. code-block:: csharp
@@ -485,7 +488,8 @@ The results of the preceding example contain the following documents:
    { "_id" : ObjectId("573a13b6f29313caabd477fa"), "plot" : "With the help of his uncle, a man travels to the future to try and bring his girlfriend back to life.", "title" : "Love Story 2050" }
    { "_id" : ObjectId("573a13e5f29313caabdc40c9"), "plot" : "A dimension-traveling wizard gets stuck in the 21st century because cell-phone radiation interferes with his magic. With his home world on the brink of war, he seeks help from a jaded ...", "title" : "The Portal" }
 
-To learn more about Atlas Vector Search, see :atlas:`Atlas Vector Search Overview </atlas-vector-search/vector-search-overview/>`
+To learn more about Atlas Vector Search, see
+:atlas:`Atlas Vector Search Overview </atlas-vector-search/vector-search-overview/>`
 in the Atlas manual.
 
 Additional Information

--- a/source/fundamentals/builders.txt
+++ b/source/fundamentals/builders.txt
@@ -428,29 +428,16 @@ To learn how to construct search queries with the ``Search`` class, see
 Perform an Atlas Vector Search
 ------------------------------
 
-You can use builders to create a ``$vectorSearch`` aggregation pipeline stage to perform an
-approximate nearest neighbor search on a vector in the specified field. Your collection *must*
-have a defined Atlas Vector Search index before you can perform a vector search on your data.
+.. include:: /includes/vector-search-intro.rst
 
-.. tip::
-
-   To obtain the sample dataset used in the following example, see :ref:`csharp-quickstart`.
-   To create the sample Atlas Vector Search index used in the following example, see
-   :atlas:`Create an Atlas Vector Search Index </atlas-vector-search/create-index>` in the
-   Atlas manual.
-
-.. include:: /includes/vector-search-parameters.rst
-
-Consider the ``embedded_movies`` collection in the ``sample_mflix`` database. You
-can use a ``$vectorSearch`` stage to perform a semantic search on the ``plot_embedding``
+You can use a ``$vectorSearch`` stage to perform a semantic search on the ``plot_embedding``
 field of the documents in the collection.
-
 The following example shows how to use builders to generate an aggregation pipeline to
 perform the following operations:
 
-- Performs a vector search on the Atlas Vector Search index of the ``plot_embedding``
+- Perform a vector search on the Atlas Vector Search index of the ``plot_embedding``
   field using vector embeddings for the string ``"time travel"``
-- Fetches the ``Title`` and ``Plot`` fields from documents found in the vector search
+- Fetch the ``Title`` and ``Plot`` fields from documents found in the vector search
 
 .. code-block:: csharp
 

--- a/source/fundamentals/linq.txt
+++ b/source/fundamentals/linq.txt
@@ -640,6 +640,8 @@ defined Atlas Vector Search index before you can perform a vector search on your
    :atlas:`Create an Atlas Vector Search Index </atlas-vector-search/create-index>` in the
    Atlas manual.
 
+.. include:: /includes/vector-search-parameters.rst
+
 Consider the ``embedded_movies`` collection in the ``sample_mflix`` database. You
 can use a ``$vectorSearch`` stage to perform a semantic search on the ``plot_embedding``
 field of the documents in the collection.

--- a/source/fundamentals/linq.txt
+++ b/source/fundamentals/linq.txt
@@ -629,42 +629,10 @@ The following shows a subset of the returned results:
 $vectorSearch
 ~~~~~~~~~~~~~
 
-The ``$vectorSearch`` aggregation stage performs an *approximate nearest neighbor* search
-on a vector in the specified field. Your collection *must* have a
-defined Atlas Vector Search index before you can perform a vector search on your data.
-
-.. tip::
-
-   To obtain the sample dataset used in the following example, see :ref:`csharp-quickstart`.
-   To create the sample Atlas Vector Search index used in the following example, see
-   :atlas:`Create an Atlas Vector Search Index </atlas-vector-search/create-index>` in the
-   Atlas manual.
-
-.. include:: /includes/vector-search-parameters.rst
-
-Consider the ``embedded_movies`` collection in the ``sample_mflix`` database. You
-can use a ``$vectorSearch`` stage to perform a semantic search on the ``plot_embedding``
-field of the documents in the collection.
-
-The following ``EmbeddedMovie`` class models the documents in the ``embedded_movies``
-collection:
-
-.. code-block:: csharp
-
-   [BsonIgnoreExtraElements]
-   public class EmbeddedMovie
-   {
-      [BsonIgnoreIfDefault]
-      public string Title { get; set; }
-
-      public string Plot { get; set; }
-
-      [BsonElement("plot_embedding")]
-      public double[] Embedding { get; set; }
-   }
+.. include:: /includes/vector-search-intro.rst
 
 The following example shows how to generate a ``$vectorSearch`` stage to search
-the ``plot_embedding`` field using vector embeddings for the string ``"time travel"``:
+the ``plot_embedding`` field by using vector embeddings for the string ``"time travel"``:
 
 .. code-block:: csharp
 

--- a/source/fundamentals/linq.txt
+++ b/source/fundamentals/linq.txt
@@ -631,8 +631,9 @@ $vectorSearch
 
 .. include:: /includes/vector-search-intro.rst
 
-The following example shows how to generate a ``$vectorSearch`` stage to search
-the ``plot_embedding`` field by using vector embeddings for the string ``"time travel"``:
+   .. replacement:: mechanism 
+
+      LINQ
 
 .. code-block:: csharp
 

--- a/source/includes/vector-search-intro.rst
+++ b/source/includes/vector-search-intro.rst
@@ -1,3 +1,14 @@
+The ``$vectorSearch`` aggregation stage performs an *approximate nearest neighbor* search
+on a vector in the specified field. Your collection *must* have a
+defined Atlas Vector Search index before you can perform a vector search on your data.
+
+.. tip::
+
+   To obtain the sample dataset used in the following example, see :ref:`csharp-quickstart`.
+   To create the sample Atlas Vector Search index used in the following example, see
+   :atlas:`Create an Atlas Vector Search Index </atlas-vector-search/create-index>` in the
+   Atlas manual.
+
 To create a ``$vectorSearch`` pipeline stage, call the ``VectorSearch()`` method on a
 ``PipelineStageDefinitionBuilder`` object. The ``VectorSearch()`` method accepts the
 following parameters:
@@ -60,10 +71,27 @@ You can use the ``options`` parameter to configure your vector search operation.
      - The index to perform the vector search on.
    
        | **Data type**: {+string-data-type+}
-       | **Default**: ``null``
+       | **Default**: ``"default"``
 
    * - ``NumberOfCandidates``
      - The number of neighbors to search in the index.
    
        | **Data type**: ``int?``
        | **Default**: ``null``
+
+Consider the ``embedded_movies`` collection in the ``sample_mflix`` database.
+The following ``EmbeddedMovie`` class represents a document in this database:
+
+.. code-block:: csharp
+
+   public class EmbeddedMovie
+   {
+       [BsonElement("title")]
+       public string Title { get; set; }
+
+       [BsonElement("plot_embedding")]
+       public double[] Embedding { get; set; }
+
+       [BsonElement("score")]
+       public double Score { get; set; }
+   }

--- a/source/includes/vector-search-intro.rst
+++ b/source/includes/vector-search-intro.rst
@@ -71,7 +71,7 @@ You can use the ``options`` parameter to configure your vector search operation.
      - The index to perform the vector search on.
    
        | **Data type**: {+string-data-type+}
-       | **Default**: ``"default"``
+       | **Default**: ``null``
 
    * - ``NumberOfCandidates``
      - The number of neighbors to search in the index.
@@ -95,3 +95,12 @@ The following ``EmbeddedMovie`` class represents a document in this database:
        [BsonElement("score")]
        public double Score { get; set; }
    }
+
+You can use a ``$vectorSearch`` stage to perform a semantic search on the ``plot_embedding``
+field of the documents in the collection.
+The following example shows how to use |mechanism| to generate an aggregation pipeline to
+perform the following operations:
+
+- Perform a vector search on the Atlas Vector Search index of the ``plot_embedding``
+  field by using vector embeddings for the string ``"time travel"``
+- Fetch the ``Title`` and ``Plot`` fields from documents found in the vector search

--- a/source/includes/vector-search-parameters.rst
+++ b/source/includes/vector-search-parameters.rst
@@ -36,7 +36,7 @@ You can use the ``options`` parameter to configure your vector search operation.
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 80
+   :widths: 30 70
 
    * - Property
      - Description

--- a/source/includes/vector-search-parameters.rst
+++ b/source/includes/vector-search-parameters.rst
@@ -47,23 +47,23 @@ You can use the ``options`` parameter to configure your vector search operation.
        neighbor (ANN) algorithm. If this property is set to ``true``, the
        ``NumberOfCandidates`` property must be ``null``.
    
-       **Data type**: {+bool-data-type+}
+       | **Data type**: {+bool-data-type+}
        | **Default**: ``false``
 
    * - ``Filter``
      - Additional search criteria that the found documents must match.
    
-       **Data Type:** `FilterDefinition<TDocument> <{+new-api-root+}/MongoDB.Driver/MongoDB.Driver.FilterDefinition-1.html>`__
+       | **Data Type:** `FilterDefinition<TDocument> <{+new-api-root+}/MongoDB.Driver/MongoDB.Driver.FilterDefinition-1.html>`__
        | **Default**: ``null``
    
    * - ``IndexName``
      - The index to perform the vector search on.
    
-       **Data type**: {+string-data-type+}
+       | **Data type**: {+string-data-type+}
        | **Default**: ``null``
 
    * - ``NumberOfCandidates``
      - The number of neighbors to search in the index.
    
-       **Data type**: ``int?``
+       | **Data type**: ``int?``
        | **Default**: ``null``

--- a/source/includes/vector-search-parameters.rst
+++ b/source/includes/vector-search-parameters.rst
@@ -1,0 +1,68 @@
+To create a ``$vectorSearch`` pipeline stage, call the ``VectorSearch()`` method on a
+``PipelineStageDefinitionBuilder`` object. The ``VectorSearch()`` method accepts the
+following parameters:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Parameter
+     - Description
+
+   * - ``field``
+     - The field to perform the vector search on.
+
+       **Data type**: ``Expression<Func<TInput, TField>>``
+
+   * - ``queryVector``
+     - The encoded vector that will be matched with values from the database.
+       Although the data type of this parameter is ``QueryVector``, you can also pass an
+       array of floating-point numbers.
+       
+       **Data type**: `QueryVector <{+new-api-root+}/MongoDB.Driver/MongoDB.Driver.QueryVector.html>`__
+
+   * - ``limit``
+     - The maximum number of documents to return.
+   
+       **Data type**: {+int-data-type+}
+   
+   * - ``options``
+     - Configuration options for the vector search operation.
+    
+       **Data type**: `VectorSearchOptions<TDocument> <{+new-api-root+}/MongoDB.Driver/MongoDB.Driver.VectorSearchOptions-1.html>`__
+
+You can use the ``options`` parameter to configure your vector search operation. The
+``VectorSearchOptions`` class contains the following properties:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Property
+     - Description
+
+   * - ``Exact``
+     - Whether the vector search uses the exact nearest neighbor (ENN) algorithm.
+       If this property is set to ``false``, the vector search uses the approximate nearest
+       neighbor (ANN) algorithm.
+   
+       **Data type**: {+bool-data-type+}
+       **Default**: ``false``
+
+   * - ``Filter``
+     - Additional search criteria that the found documents must match.
+   
+       **Data Type:** `FilterDefinition<TDocument> <{+new-api-root+}/MongoDB.Driver/MongoDB.Driver.FilterDefinition-1.html>`__
+       **Default**: ``null``
+   
+   * - ``IndexName``
+     - The index to perform the vector search on.
+   
+       **Data type**: {+string-data-type+}
+       **Default**: ``null``
+
+   * - ``NumberOfCandidates``
+     - The number of neighbors to search in the index.
+   
+       **Data type**: ``int?``
+       **Default**: ``null``

--- a/source/includes/vector-search-parameters.rst
+++ b/source/includes/vector-search-parameters.rst
@@ -44,25 +44,26 @@ You can use the ``options`` parameter to configure your vector search operation.
    * - ``Exact``
      - Whether the vector search uses the exact nearest neighbor (ENN) algorithm.
        If this property is set to ``false``, the vector search uses the approximate nearest
-       neighbor (ANN) algorithm.
+       neighbor (ANN) algorithm. If this property is set to ``true``, the
+       ``NumberOfCandidates`` property must be ``null``.
    
        **Data type**: {+bool-data-type+}
-       **Default**: ``false``
+       | **Default**: ``false``
 
    * - ``Filter``
      - Additional search criteria that the found documents must match.
    
        **Data Type:** `FilterDefinition<TDocument> <{+new-api-root+}/MongoDB.Driver/MongoDB.Driver.FilterDefinition-1.html>`__
-       **Default**: ``null``
+       | **Default**: ``null``
    
    * - ``IndexName``
      - The index to perform the vector search on.
    
        **Data type**: {+string-data-type+}
-       **Default**: ``null``
+       | **Default**: ``null``
 
    * - ``NumberOfCandidates``
      - The number of neighbors to search in the index.
    
        **Data type**: ``int?``
-       **Default**: ``null``
+       | **Default**: ``null``

--- a/source/includes/vector-search-parameters.rst
+++ b/source/includes/vector-search-parameters.rst
@@ -17,7 +17,7 @@ following parameters:
    * - ``queryVector``
      - The encoded vector that will be matched with values from the database.
        Although the data type of this parameter is ``QueryVector``, you can also pass an
-       array of floating-point numbers.
+       array of ``float`` values.
        
        **Data type**: `QueryVector <{+new-api-root+}/MongoDB.Driver/MongoDB.Driver.QueryVector.html>`__
 


### PR DESCRIPTION
`Exact` property will be backported only back to v3.1.

# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-golang/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-45048>

### Staging Links
<!-- start insert-links -->
<li><a href=https://deploy-preview-517--docs-csharp.netlify.app/fundamentals/builders>fundamentals/builders</a></li><li><a href=https://deploy-preview-517--docs-csharp.netlify.app/fundamentals/linq>fundamentals/linq</a></li>
<!-- end insert-links -->

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
- [x] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
