### PR TITLE
DOCSP-48120: elemmatch method overload

### DIFF
--- a/source/fundamentals/builders.txt
+++ b/source/fundamentals/builders.txt
@@ -130,8 +130,8 @@ criteria. The following example returns documents that contain the value
 
 .. tip:: ElemMatch() Overload
 
-   The ``ElemMatch()`` method has an overload to accept a single filter
-   parameter. This functionality supports performing queries that
+   The ``ElemMatch()`` method has an overload that accepts a single filter
+   parameter. You can use this overload to perform queries that
    include nested ``$elemMatch`` statements.
 
    The following code demonstrates how to construct a nested

--- a/source/fundamentals/builders.txt
+++ b/source/fundamentals/builders.txt
@@ -130,9 +130,10 @@ criteria. The following example returns documents that contain the value
 
 .. tip:: ElemMatch() Overload
 
-   The ``ElemMatch()`` method has an overload that accepts a single filter
-   parameter. You can use this overload to perform queries that
-   include nested ``$elemMatch`` statements.
+   The ``ElemMatch()`` method has an overload that accepts a single *filter*
+   parameter. You can use this overload to perform ``$elemMatch``
+   queries directly against values. This functionality can support
+   queries that include nested ``$elemMatch`` statements.
 
    The following code demonstrates how to construct a nested
    ``$elemMatch`` query that uses multiple overloads of the

--- a/source/fundamentals/builders.txt
+++ b/source/fundamentals/builders.txt
@@ -135,7 +135,7 @@ criteria. The following example returns documents that contain the value
    include nested ``$elemMatch`` statements.
 
    The following code demonstrates how to construct a nested
-   ``$elemMatch`` query that uses both implementations of the
+   ``$elemMatch`` query that uses multiple overloads of the
    ``ElemMatch()`` method:
 
    .. code-block:: csharp

--- a/source/fundamentals/builders.txt
+++ b/source/fundamentals/builders.txt
@@ -128,6 +128,24 @@ criteria. The following example returns documents that contain the value
    var builder = Builders<Flower>.Filter;
    var filter = builder.ElemMatch(f => f.Season, s => s == "Summer");
 
+.. tip:: ElemMatch() Overload
+
+   The ``ElemMatch()`` method has an overload to accept a single filter
+   parameter. This functionality supports performing queries that
+   include nested ``$elemMatch`` statements.
+
+   The following code demonstrates how to construct a nested
+   ``$elemMatch`` query that uses both implementations of the
+   ``ElemMatch()`` method:
+
+   .. code-block:: csharp
+
+      // ElemMatch() with only filter parameter
+      var arrayFilter = Builders<MyEntry[]>.Filter.ElemMatch(<filter>);
+
+      // ElemMatch() with field name and filter parameters
+      var filter = Builders<MyClass>.Filter.ElemMatch(<array field name>, arrayFilter);
+
 To learn more about array operators, see the :manual:`Array Query Operators
 </reference/operator/query-array/>` guide in the {+mdb-server+} manual.
 
@@ -493,4 +511,5 @@ guide, see the following API Documentation:
 - `SortDefinitionBuilder <{+new-api-root+}/MongoDB.Driver/MongoDB.Driver.SortDefinitionBuilder-1.html>`__
 - `UpdateDefinitionBuilder <{+new-api-root+}/MongoDB.Driver/MongoDB.Driver.UpdateDefinitionBuilder-1.html>`__
 - `IndexKeysDefinitionBuilder <{+new-api-root+}/MongoDB.Driver/MongoDB.Driver.IndexKeysDefinitionBuilder-1.html>`__
-- `PipelineDefinitionBuilder <{+new-api-root+}/MongoDB.Driver/MongoDB.Driver.PipelineDefinitionBuilder.html>`__
+- `PipelineDefinitionBuilder
+  <{+new-api-root+}/MongoDB.Driver/MongoDB.Driver.PipelineDefinitionBuilder.html>`__

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -74,9 +74,10 @@ The 3.3 driver release includes the following new features:
 - Adds support for the ``$rankFusion`` aggregation stage, which enables rank-based
   result scoring on combined results from multiple pipelines.
 
-- Adds support for nested :manual:`$elemMatch </reference/operator/query/elemMatch/>`
-  queries by providing an overload of the ``ElemMatch()`` method that takes only a filter
-  parameter. To learn more, see the :ref:`csharp-builders-array-operators` section of the
+- Adds support for :manual:`$elemMatch </reference/operator/query/elemMatch/>`
+  queries directly against values by providing an overload of the
+  ``ElemMatch()`` method that takes only a filter parameter. To learn
+  more, see the :ref:`csharp-builders-array-operators` section of the
   Builders guide.
 
 - Adds support for using the ``OfType<T>()`` method and ``is`` operator to check


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-golang/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-48120>

### Staging Links
- [builders page](https://deploy-preview-537--docs-csharp.netlify.app/fundamentals/builders/#array-operators)
- [whats new](https://deploy-preview-537--docs-csharp.netlify.app/whats-new/#what-s-new-in-3.3)

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
- [x] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
